### PR TITLE
Deal with empty or null callbacks

### DIFF
--- a/ri.api.manager/src/main/java/org/universAAL/ri/api/manager/Configuration.java
+++ b/ri.api.manager/src/main/java/org/universAAL/ri/api/manager/Configuration.java
@@ -111,6 +111,9 @@ public class Configuration {
 	 *         RemoteAPI.REMOTE_UNKNOWN if anything else
 	 */
 	public static int determineEndpoint(String remote) {
+		if (remote==null || remote.isEmpty() || remote.equals("null")){
+			return RemoteAPI.REMOTE_UNKNOWN;
+		}
 		try {
 			URL attempt = new URL(remote);
 			if (attempt.getProtocol().toLowerCase().startsWith("http")) {

--- a/ri.rest.manager/src/main/java/org/universAAL/ri/rest/manager/push/PushManager.java
+++ b/ri.rest.manager/src/main/java/org/universAAL/ri/rest/manager/push/PushManager.java
@@ -87,6 +87,9 @@ public class PushManager {
 	 *         RemoteAPI.REMOTE_UNKNOWN if anything else
 	 */
 	public static int determineEndpoint(String remote) {
+		if (remote==null || remote.isEmpty() || remote.equals("null")){
+			return REMOTE_UNKNOWN;
+		}
 		try {
 			URL attempt = new URL(remote);
 			if (attempt.getProtocol().toLowerCase().startsWith("http")) {


### PR DESCRIPTION
Prevents sending to non-existing HTTP or GCM endpoints when there is an
error in the submited callback string or it is missing (accidentally or
deliberately, allowing push-only)